### PR TITLE
Metadata API cleanup

### DIFF
--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -85,11 +85,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/data_dictionary_list'
+                type: array
+                items:
+                  $ref: '#/components/schemas/data_dictionary'
         '401':
           description: Unauthorized (401)
         '404':
-          description: Not Found (404) - Dataset not found.
+          description: Not Found (404) - Dictionaries not found.
       tags:
         - Metadata API
       operationId: get-dictionaries
@@ -188,66 +190,6 @@ components:
         - id
         - title
         - creator
-    data_dictionary_list:
-      description: A list of dataset dictionaries for a particular dataset.
-      type: object
-      properties:
-        dictionaries:
-          type: array
-          items:
-            $ref: '#/components/schemas/data_dictionary'
-      example:
-        dictionaries:
-          - id: table_1
-            fields:
-              - name: sex
-                label: Sex
-                type: text
-                description: 'Sex of patient, factor with levels (F or M)'
-                constraints: SEX
-              - name: age_brc
-                label: Age
-                type: text
-                description: 'Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3).'
-                constraints: AGE
-            lookups:
-              AGE:
-                - name: B1
-                  description: Bracket 1 - 18-25
-                - name: B2
-                  description: Bracket 2 - 25-50
-                - name: B3
-                  description: Bracket 3 - 50+
-              SEX:
-                - name: F
-                  description: female
-                - name: M
-                  description: male
-          - id: table_2
-            fields:
-              - name: sex
-                label: Sex
-                type: text
-                description: 'Sex of patient, factor with levels (F or M)'
-                constraints: SEX
-              - name: age_brc
-                label: Age
-                type: text
-                description: 'Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3).'
-                constraints: AGE
-            lookups:
-              AGE:
-                - name: B1
-                  description: Bracket 1 - 18-25
-                - name: B2
-                  description: Bracket 2 - 25-50
-                - name: B3
-                  description: Bracket 3 - 50+
-              SEX:
-                - name: F
-                  description: female
-                - name: M
-                  description: male
     data_dictionary:
       description: An object containing the list of fields and lookups for a particular dataset table.
       required:

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -31,7 +31,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/dataset_summary'
+                  $ref: '#/components/schemas/DCAT_metadata'
         '401':
           description: Unauthorized (401)
       tags:
@@ -63,34 +63,6 @@ paths:
       tags:
         - Metadata API
       operationId: get-dataset
-  '/datasets/{datasetid}/catalogue':
-    get:
-      summary: Get Catalogue entry (metadata) for dataset.
-      description: Returns the catalogue metadata for a specified dataset (by dataset ID).
-      parameters:
-        - name: datasetid
-          in: path
-          description: Dataset ID
-          required: true
-          style: simple
-          explode: false
-          schema:
-            type: string
-          example: hospital_a_patient_results
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DCAT_metadata'
-        '401':
-          description: Unauthorized (401)
-        '404':
-          description: Not Found (404) - Dataset not found.
-      tags:
-        - Metadata API
-      operationId: get-catalogue
   '/datasets/{datasetid}/dictionaries':
     get:
       summary: Get Dictionaries (field descriptions) for dataset.
@@ -168,22 +140,6 @@ paths:
       description: Liveness Probe
 components:
   schemas:
-    dataset_summary:
-      description: 'A summary of a dataset, including the dataset ID, the dataset name, and the author of the dataset.'
-      required:
-        - id
-      type: object
-      properties:
-        id:
-          type: string
-        dataset_name:
-          type: string
-        author:
-          type: string
-      example:
-        id: hospital_a_patient_results
-        dataset_name: Hospital A Patient Results
-        author: John Smith
     dataset_information:
       description: A combined object of metadata from the catalogue entry and the dictionary field descriptions.
       required:

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -61,7 +61,7 @@ paths:
         '401':
           description: Unauthorized (401)
         '404':
-          description: Not Found
+          description: Not Found (404) - Dataset not found
       tags:
         - Metadata API
       operationId: get-dataset
@@ -128,7 +128,7 @@ paths:
         '401':
           description: Unauthorized (401)
         '404':
-          description: Not Found (404) - Dataset not found.
+          description: Not Found (404) - Dictionary not found.
       tags:
         - Metadata API
       operationId: get-table

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -57,9 +57,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/dataset_information'
+                $ref: '#/components/schemas/DCAT_metadata'
         '401':
           description: Unauthorized (401)
+        '404':
+          description: Not Found
       tags:
         - Metadata API
       operationId: get-dataset
@@ -140,19 +142,6 @@ paths:
       description: Liveness Probe
 components:
   schemas:
-    dataset_information:
-      description: A combined object of metadata from the catalogue entry and the dictionary field descriptions.
-      required:
-        - catalogue
-        - dictionaries
-      type: object
-      properties:
-        catalogue:
-          $ref: '#/components/schemas/DCAT_metadata'
-        dictionaries:
-          type: array
-          items:
-            $ref: '#/components/schemas/data_dictionary'
     DCAT_metadata:
       description: A catalogue of the dataset metadata defined to the DCAT specifications.
       type: object

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -29,7 +29,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/dataset_list'
+                type: array
+                items:
+                  $ref: '#/components/schemas/dataset_summary'
         '401':
           description: Unauthorized (401)
       tags:
@@ -166,24 +168,6 @@ paths:
       description: Liveness Probe
 components:
   schemas:
-    dataset_list:
-      description: A list of dataset summaries.
-      required:
-        - datasets
-      type: object
-      properties:
-        datasets:
-          type: array
-          items:
-            $ref: '#/components/schemas/dataset_summary'
-      example:
-        datasets:
-          - id: hospital_a_patient_results
-            dataset_name: Hospital A Patient Results
-            author: John Smith
-          - id: medical_trial_b_results
-            dataset_name: Medical Trial B Results
-            author: Jane Jones
     dataset_summary:
       description: 'A summary of a dataset, including the dataset ID, the dataset name, and the author of the dataset.'
       required:

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -1,5 +1,4 @@
 openapi: 3.0.0
-
 info:
   title: Common API for Federated Data Sharing
   description: |
@@ -7,44 +6,39 @@ info:
     The API has three parts Metadata, Selection and Tasks. A site must implement the Metadata API, 
     and it can either implement the Selection API or the Tasks API. In the case that the Tasks API
     is implemented, the Selection API must be implemented as input to compute tasks. 
-    
+
     This schema describes the Metadata API. The Selection API and Tasks API are houlsed in their
     own repositories in separate files.
-  version: "1.1.0"
-
+  version: 1.1.0
+  contact:
+    name: 'International COVID-19 Research Data Alliance '
 externalDocs:
   description: Common API for Federated Data Sharing Github repository
-  url: https://github.com/federated-data-sharing/common-api
-  
+  url: 'https://github.com/federated-data-sharing/common-api'
 tags:
   - name: Metadata API
   - name: Health Check
-
-
 paths:
   /datasets:
     get:
       summary: Get a list of available datasets.
       description: Shows the list of all datasets available for querying.
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/dataset_list"
-        "401":
+                $ref: '#/components/schemas/dataset_list'
+        '401':
           description: Unauthorized (401)
-          
       tags:
         - Metadata API
-   
-   
-  /datasets/{datasetid}:
+      operationId: list-datasets
+  '/datasets/{datasetid}':
     get:
       summary: Get Catalogue entry (metadata) and Dictionaries (field descriptions) for dataset.
       description: Returns the catalogue metadata and a list of field descriptions for a specified dataset (by dataset ID).
-      
       parameters:
         - name: datasetid
           in: path
@@ -54,28 +48,23 @@ paths:
           explode: false
           schema:
             type: string
-          example:
-            "hospital_a_patient_results"
-            
+          example: hospital_a_patient_results
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/dataset_information"
-        "401":
+                $ref: '#/components/schemas/dataset_information'
+        '401':
           description: Unauthorized (401)
-          
       tags:
         - Metadata API
-      
-      
-  /datasets/{datasetid}/catalogue:
+      operationId: get-dataset
+  '/datasets/{datasetid}/catalogue':
     get:
-      summary: Get Catalogue entry (metadata) for dataset. 
+      summary: Get Catalogue entry (metadata) for dataset.
       description: Returns the catalogue metadata for a specified dataset (by dataset ID).
-
       parameters:
         - name: datasetid
           in: path
@@ -85,30 +74,25 @@ paths:
           explode: false
           schema:
             type: string
-          example:
-            "hospital_a_patient_results"
-
+          example: hospital_a_patient_results
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DCAT_metadata"
-        "401":
+                $ref: '#/components/schemas/DCAT_metadata'
+        '401':
           description: Unauthorized (401)
-        "404":
+        '404':
           description: Not Found (404) - Dataset not found.
-      
       tags:
         - Metadata API
-        
-
-  /datasets/{datasetid}/dictionaries:
+      operationId: get-catalogue
+  '/datasets/{datasetid}/dictionaries':
     get:
       summary: Get Dictionaries (field descriptions) for dataset.
       description: Returns a list of field descriptions for each table within a specified dataset (by dataset ID).
-
       parameters:
         - name: datasetid
           in: path
@@ -118,30 +102,25 @@ paths:
           explode: false
           schema:
             type: string
-          example:
-            "hospital_a_patient_results"
-
+          example: hospital_a_patient_results
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/data_dictionary_list"
-        "401":
+                $ref: '#/components/schemas/data_dictionary_list'
+        '401':
           description: Unauthorized (401)
-        "404":
+        '404':
           description: Not Found (404) - Dataset not found.
-          
       tags:
         - Metadata API
-      
-      
-  /datasets/{datasetid}/dictionaries/{tableid}:
+      operationId: get-dictionaries
+  '/datasets/{datasetid}/dictionaries/{tableid}':
     get:
       summary: Get a single dataset Dictionary for a specified table.
       description: Returns a set field descriptions for the specified table (by table ID) within a specified dataset (by dataset ID).
-
       parameters:
         - name: datasetid
           in: path
@@ -151,8 +130,7 @@ paths:
           explode: false
           schema:
             type: string
-          example:
-            "hospital_a_patient_results"
+          example: hospital_a_patient_results
         - name: tableid
           in: path
           description: Table ID
@@ -161,39 +139,35 @@ paths:
           explode: false
           schema:
             type: string
-          example:
-            "table_1"
-
+          example: table_1
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/data_dictionary"
-        "401":
+                $ref: '#/components/schemas/data_dictionary'
+        '401':
           description: Unauthorized (401)
-        "404":
+        '404':
           description: Not Found (404) - Dataset not found.
-          
       tags:
         - Metadata API
-      
+      operationId: get-table
   /healthz:
     get:
       summary: Get a health check of the service.
       responses:
-        200:
+        '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/health_check"
-                
+                $ref: '#/components/schemas/health_check'
       tags:
         - Health Check
-
-
+      operationId: get-health-status
+      description: Liveness Probe
 components:
   schemas:
     dataset_list:
@@ -205,19 +179,17 @@ components:
         datasets:
           type: array
           items:
-            $ref: "#/components/schemas/dataset_summary"
-
+            $ref: '#/components/schemas/dataset_summary'
       example:
         datasets:
-          - id: "hospital_a_patient_results"
-            dataset_name: "Hospital A Patient Results"
-            author: "John Smith"
-          - id: "medical_trial_b_results"
-            dataset_name: "Medical Trial B Results"
-            author: "Jane Jones"
-
+          - id: hospital_a_patient_results
+            dataset_name: Hospital A Patient Results
+            author: John Smith
+          - id: medical_trial_b_results
+            dataset_name: Medical Trial B Results
+            author: Jane Jones
     dataset_summary:
-      description: A summary of a dataset, including the dataset ID, the dataset name, and the author of the dataset.
+      description: 'A summary of a dataset, including the dataset ID, the dataset name, and the author of the dataset.'
       required:
         - id
       type: object
@@ -228,12 +200,10 @@ components:
           type: string
         author:
           type: string
-
       example:
-        id: "hospital_a_patient_results"
-        dataset_name: "Hospital A Patient Results"
-        author: "John Smith"
-    
+        id: hospital_a_patient_results
+        dataset_name: Hospital A Patient Results
+        author: John Smith
     dataset_information:
       description: A combined object of metadata from the catalogue entry and the dictionary field descriptions.
       required:
@@ -242,12 +212,11 @@ components:
       type: object
       properties:
         catalogue:
-          $ref: "#/components/schemas/DCAT_metadata"
+          $ref: '#/components/schemas/DCAT_metadata'
         dictionaries:
           type: array
           items:
-            $ref: "#/components/schemas/data_dictionary"
-      
+            $ref: '#/components/schemas/data_dictionary'
     DCAT_metadata:
       description: A catalogue of the dataset metadata defined to the DCAT specifications.
       required:
@@ -265,28 +234,30 @@ components:
         contactPoint:
           type: string
         publisher:
-          $ref: "#/components/schemas/DCAT_metadata_publisher"
+          $ref: '#/components/schemas/DCAT_metadata_publisher'
         license:
           type: string
         versionInfo:
           type: string
         additionalProperties:
           type: object
-
       example:
-        id: "medical_trial_b_results"
-        title: "Medical Trail B Results"
-        description: "A description of the example medical trial and the data contained in this example."
-        creator: "Jane Jones"
-        contactPoint: "jane.jones@example.com"
+        id: medical_trial_b_results
+        title: Medical Trail B Results
+        description: A description of the example medical trial and the data contained in this example.
+        creator: Jane Jones
+        contactPoint: jane.jones@example.com
         publisher:
-          name: "Example Medical Trial Org"
-          url: "www.examplemedicaltrial.org"
-        license: "https://creativecommons.org/licenses/by/3.0/"
-        versionInfo: "1.0"
-        additionalProperties: {additional_tags: ["tag1", "tag2", "tag3"], extra_info: "Some additional information."}
-        
-
+          name: Example Medical Trial Org
+          url: www.examplemedicaltrial.org
+        license: 'https://creativecommons.org/licenses/by/3.0/'
+        versionInfo: '1.0'
+        additionalProperties:
+          additional_tags:
+            - tag1
+            - tag2
+            - tag3
+          extra_info: Some additional information.
     DCAT_metadata_publisher:
       description: An object containing the publisher name and url for the DCAT catalogue.
       required:
@@ -298,11 +269,9 @@ components:
           type: string
         url:
           type: string
-
       example:
-        name: "Example Medical Trial Org"
-        url: "www.examplemedicaltrial.org"
-
+        name: Example Medical Trial Org
+        url: www.examplemedicaltrial.org
     data_dictionary_list:
       description: A list of dataset dictionaries for a particular dataset.
       type: object
@@ -310,44 +279,59 @@ components:
         dictionaries:
           type: array
           items:
-            $ref: "#/components/schemas/data_dictionary"
-
+            $ref: '#/components/schemas/data_dictionary'
       example:
         dictionaries:
-          - id: "table_1"
+          - id: table_1
             fields:
-              - name: "sex"
-                label: "Sex"
-                type: "text"
-                description: "Sex of patient, factor with levels (F or M)"
-                constraints: "SEX"
-              - name: "age_brc"
-                label: "Age"
-                type: "text"
-                description: "Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3)."
-                constraints: "AGE"
-            lookups: {
-                AGE: [{name: "B1", description: "Bracket 1 - 18-25"},
-                  {name: "B2", description: "Bracket 2 - 25-50"},
-                  {name: "B3", description: "Bracket 3 - 50+"}],
-                SEX: [{name: "F", description: "female"}, {name: "M", description: "male"}]}
-          - id: "table_2"
+              - name: sex
+                label: Sex
+                type: text
+                description: 'Sex of patient, factor with levels (F or M)'
+                constraints: SEX
+              - name: age_brc
+                label: Age
+                type: text
+                description: 'Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3).'
+                constraints: AGE
+            lookups:
+              AGE:
+                - name: B1
+                  description: Bracket 1 - 18-25
+                - name: B2
+                  description: Bracket 2 - 25-50
+                - name: B3
+                  description: Bracket 3 - 50+
+              SEX:
+                - name: F
+                  description: female
+                - name: M
+                  description: male
+          - id: table_2
             fields:
-              - name: "sex"
-                label: "Sex"
-                type: "text"
-                description: "Sex of patient, factor with levels (F or M)"
-                constraints: "SEX"
-              - name: "age_brc"
-                label: "Age"
-                type: "text"
-                description: "Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3)."
-                constraints: "AGE"
-            lookups: {AGE: [{name: "B1", description: "Bracket 1 - 18-25"},
-                  {name: "B2", description: "Bracket 2 - 25-50"},
-                  {name: "B3", description: "Bracket 3 - 50+"}],
-                SEX: [{name: "F", description: "female"}, {name: "M", description: "male"}]}
-
+              - name: sex
+                label: Sex
+                type: text
+                description: 'Sex of patient, factor with levels (F or M)'
+                constraints: SEX
+              - name: age_brc
+                label: Age
+                type: text
+                description: 'Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3).'
+                constraints: AGE
+            lookups:
+              AGE:
+                - name: B1
+                  description: Bracket 1 - 18-25
+                - name: B2
+                  description: Bracket 2 - 25-50
+                - name: B3
+                  description: Bracket 3 - 50+
+              SEX:
+                - name: F
+                  description: female
+                - name: M
+                  description: male
     data_dictionary:
       description: An object containing the list of fields and lookups for a particular dataset table.
       required:
@@ -359,29 +343,36 @@ components:
         fields:
           type: array
           items:
-            $ref: "#/components/schemas/data_dictionary_field"
+            $ref: '#/components/schemas/data_dictionary_field'
         lookups:
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/data_dictionary_lookup"
-
+            $ref: '#/components/schemas/data_dictionary_lookup'
       example:
-        id: "table_1"
+        id: table_1
         fields:
-              - name: "sex"
-                label: "Sex"
-                type: "text"
-                description: "Sex of patient, factor with levels (F or M)"
-                constraints: "SEX"
-              - name: "age_brc"
-                label: "Age"
-                type: "text"
-                description: "Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3)."
-        lookups: {AGE: [{name: "B1", description: "Bracket 1 - 18-25"},
-            {name: "B2", description: "Bracket 2 - 25-50"},
-            {name: "B3", description: "Bracket 3 - 50+"}],
-          SEX: [{name: "F", description: "female"}, {name: "M", description: "male"}]}
-
+          - name: sex
+            label: Sex
+            type: text
+            description: 'Sex of patient, factor with levels (F or M)'
+            constraints: SEX
+          - name: age_brc
+            label: Age
+            type: text
+            description: 'Age group, of the forms 18-25 (B1), 25-50 (B2), 50+ (B3).'
+        lookups:
+          AGE:
+            - name: B1
+              description: Bracket 1 - 18-25
+            - name: B2
+              description: Bracket 2 - 25-50
+            - name: B3
+              description: Bracket 3 - 50+
+          SEX:
+            - name: F
+              description: female
+            - name: M
+              description: male
     data_dictionary_field:
       description: A description of a field entry in the dataset table.
       required:
@@ -400,20 +391,17 @@ components:
           type: string
         constraints:
           type: string
-
       example:
-        name: "sex"
-        label: "Sex"
-        type: "text"
-        description: "Sex of patient, factor with levels (F or M)"
-        constraints: "SEX"
-
+        name: sex
+        label: Sex
+        type: text
+        description: 'Sex of patient, factor with levels (F or M)'
+        constraints: SEX
     data_dictionary_lookup:
       description: A list of lookups for field entries in the dataset dictionary. The items can be arbitrarily named but follow a defined structure.
       type: array
       items:
-        $ref: "#/components/schemas/data_dictionary_lookup_inner"
-
+        $ref: '#/components/schemas/data_dictionary_lookup_inner'
     data_dictionary_lookup_inner:
       description: A lookup reference for field entries in the dataset dictionary.
       required:
@@ -425,11 +413,9 @@ components:
           type: string
         description:
           type: string
-
       example:
-        name: "F" 
-        description: "female"
-        
+        name: F
+        description: female
     health_check:
       description: A response
       type: object
@@ -439,17 +425,18 @@ components:
         health_check:
           type: boolean
       example:
-        version: "1.1.0"
+        version: 1.1.0
         health_check: true
-        
-
   securitySchemes:
     oAuth2Implicit:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: https://example.org/api/authorize
+          authorizationUrl: 'https://example.org/api/authorize'
           scopes:
-            api://example_id/read_api: allows reading resources
+            'api://example_id/read_api': allows reading resources
       x-tokenInfoFunc: common_api_server.controllers.authorization_controller.check_oAuth2Implicit
       x-scopeValidateFunc: common_api_server.controllers.authorization_controller.validate_scope_oAuth2Implicit
+servers:
+  - url: 'http://localhost:8080/api/v1'
+    description: ''

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -155,28 +155,7 @@ components:
             $ref: '#/components/schemas/data_dictionary'
     DCAT_metadata:
       description: A catalogue of the dataset metadata defined to the DCAT specifications.
-      required:
-        - id
       type: object
-      properties:
-        id:
-          type: string
-        title:
-          type: string
-        description:
-          type: string
-        creator:
-          type: string
-        contactPoint:
-          type: string
-        publisher:
-          $ref: '#/components/schemas/DCAT_metadata_publisher'
-        license:
-          type: string
-        versionInfo:
-          type: string
-        additionalProperties:
-          type: object
       example:
         id: medical_trial_b_results
         title: Medical Trail B Results
@@ -194,20 +173,32 @@ components:
             - tag2
             - tag3
           extra_info: Some additional information.
-    DCAT_metadata_publisher:
-      description: An object containing the publisher name and url for the DCAT catalogue.
-      required:
-        - name
-        - url
-      type: object
       properties:
-        name:
+        id:
           type: string
-        url:
+        title:
           type: string
-      example:
-        name: Example Medical Trial Org
-        url: www.examplemedicaltrial.org
+        description:
+          type: string
+        creator:
+          type: string
+        contactPoint:
+          type: string
+        publisher:
+          type: object
+          properties:
+            name:
+              type: string
+            url:
+              type: string
+        license:
+          type: string
+        version:
+          type: string
+      required:
+        - id
+        - title
+        - creator
     data_dictionary_list:
       description: A list of dataset dictionaries for a particular dataset.
       type: object

--- a/api/common_api.yaml
+++ b/api/common_api.yaml
@@ -160,10 +160,6 @@ paths:
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/health_check'
       tags:
         - Health Check
       operationId: get-health-status
@@ -416,17 +412,6 @@ components:
       example:
         name: F
         description: female
-    health_check:
-      description: A response
-      type: object
-      properties:
-        version:
-          type: string
-        health_check:
-          type: boolean
-      example:
-        version: 1.1.0
-        health_check: true
   securitySchemes:
     oAuth2Implicit:
       type: oauth2


### PR DESCRIPTION
### General cleanup PR for Metadata API - [Swagger](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/susheel/common-api-metadata/patch-1/api/common_api.yaml)


#### Commits - [Diff](https://github.com/federated-data-sharing/common-api-metadata/pull/1/files):
- 3da38fe - General Cleanup
  - Added:
    - Servers: localhost
    - API Contact
    - operationIds
- b470639 - Fixed /healthz response
  - Only 200 OK response required
- 0ecd663 - Removing dataset_list object
  - Unecessary
- ba94faa - Removing /datasets/{ID}/catalogue endpoint
  - Uneccessary endpoint to get DCAT_metadata which could be provided directly by /datasets
  - Using array(DCAT_metadata) for /datasets
- 32b4ee3 - Cleaned up DCAT_metadata definition
  - Removed addionalProperties object
  - Converted DCAT_metadata_publisher into embedded object
  - Made id, title, creator as required properties to align to OLD dataset_summary
- 0023549 - Cleaning /datasets/{datasetID} endpoint
  - Using DCAT_metadata as a response for /datasets/{datasetID}
  - Added 404 response for datasetID not found
  - Removing dataset_information definition
- 03c6985 - Updating /datasets/{datasetID}/dictionaries
  - Response updated to array(data_dictionary)
  - Removing data_dictionary_list
- 2e74a15 - Updating 404 responses